### PR TITLE
improve rener order when editorMode change

### DIFF
--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -48,7 +48,6 @@ const Content: React.FC<Props> = ({ note }) => {
     DELETE_NOTE,
     {
       variables: { id: note.id },
-      onCompleted: () => setEditorMode(EditorMode.View),
       update: (cache, result) => {
         if (result.data?.deleteNote) {
           cache.modify({
@@ -71,9 +70,7 @@ const Content: React.FC<Props> = ({ note }) => {
   const [updateNote, { loading }] = useMutation<
     UpdateNote,
     UpdateNoteVariables
-  >(UPDATE_NOTE, {
-    onCompleted: () => setEditorMode(EditorMode.View),
-  });
+  >(UPDATE_NOTE);
 
   const onSave = useCallback(async () => {
     if (clearContent !== null) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,10 @@
 import queryString from 'query-string';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import Content from '@/components/Content';
 import NotesList from '@/components/NotesList';
+import { EditorMode } from '@/constants';
+import { setEditorMode } from '@/gql/editorModeCache';
 import { GET_NOTE, GET_NOTES } from '@/gql/queries';
 import AppLayout from '@/layouts/App';
 import { GetNote, GetNoteVariables, GetNotes } from '@/typings/gql';
@@ -17,6 +19,11 @@ const App = () => {
     variables: { id: noteId },
     skip: !noteId,
   });
+
+  // if noteData changed, alway back to View mode first.
+  useEffect(() => {
+    setEditorMode(EditorMode.View);
+  }, [noteData?.note]);
 
   return (
     <AppLayout>


### PR DESCRIPTION
### description

https://www.notion.so/mengtse/improve-render-order-when-click-delete-button-3d8c25859a644c8e88987bec2761fd90

Originally, we setEditorMode in onComplete function. However, it doesn't ensure executing after caching updating.

Because noteData changed means cache updated, so I add a [useEffect](https://github.com/TseHang/PtotoNote/pull/7/files#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3R24) to listen noteData changes.

In logically, if noteDate changed, we should back to view mode first.


### demo
https://www.notion.so/mengtse/improve-render-order-when-click-delete-button-3d8c25859a644c8e88987bec2761fd90#645eeb6567dc4bb1b0f3fa1affb8c471