### PR TITLE
fix ContentView loading state

### DIFF
--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -107,7 +107,8 @@ const Content: React.FC<Props> = ({ note }) => {
         <ContentView
           content={editingContent}
           onChangeContent={setEditingContent}
-          isLoading={loading || isEncrypting}
+          isLoading={clearContent === null}
+          isSaving={loading || isEncrypting}
         />
       </div>
       <ContentBottomBar

--- a/components/ContentView.tsx
+++ b/components/ContentView.tsx
@@ -8,8 +8,9 @@ import { useReactiveVar } from '@apollo/client';
 import Editor from './Editor';
 
 type Props = {
-  content: string | null;
+  content: string;
   onChangeContent: (content: string) => void;
+  isSaving?: boolean;
   isLoading?: boolean;
 };
 
@@ -17,14 +18,15 @@ const ContentView: React.FC<Props> = ({
   content,
   onChangeContent,
   isLoading,
+  isSaving,
 }) => {
   const editorMode = useReactiveVar(editorModeVar);
 
-  if (content === null) {
+  if (isLoading) {
     return <div>Loading content...</div>;
   }
 
-  if (isLoading) {
+  if (isSaving) {
     return <div>Saving...</div>;
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const App = () => {
     <AppLayout>
       <NotesList notes={notesData?.notes || []} />
       {noteData?.note && noteId && (
-        /* key for re-render when noteId changed */
+        /* key for re-mount when noteId changed */
         <Content key={noteId} note={noteData.note} />
       )}
     </AppLayout>


### PR DESCRIPTION
After merge https://github.com/TseHang/PtotoNote/pull/8, the ContentView loading text shows wrong because `content` always not be `null`.

Fix this in this pr.