### PR TITLE
Feature/auto focus when create new note

### DIFF
--- a/components/NotesList.tsx
+++ b/components/NotesList.tsx
@@ -7,7 +7,7 @@ import { editorModeVar } from '@/gql/editorModeCache';
 import { GetNotes_notes } from '@/typings/gql';
 import { useReactiveVar } from '@apollo/client';
 
-const Item = styled.a`
+const Item = styled.a<{ isActive: boolean; isEditMode: boolean }>`
   display: flex;
   margin: 0.5rem 1rem;
   padding: 0.5rem 1rem;
@@ -15,10 +15,11 @@ const Item = styled.a`
   height: 50px;
   align-items: center;
   text-decoration: none;
-  background-color: ${p => p.theme.colors.contentBackground};
+  cursor: ${p => (p.isEditMode ? 'default' : 'pointer')};
+  background-color: ${p =>
+    p.isActive ? p.theme.colors.lightMain : p.theme.colors.contentBackground};
 
   &:hover {
-    cursor: pointer;
     background-color: ${p => p.theme.colors.lightMain};
   }
 
@@ -32,6 +33,7 @@ const Item = styled.a`
 `;
 
 type Props = {
+  focusedNoteId?: string;
   notes: GetNotes_notes[];
 };
 
@@ -46,7 +48,7 @@ const LinkWrapper: React.FC<React.PropsWithChildren<LinkProps>> = ({
   </Link>
 );
 
-const NotesList: React.FC<Props> = ({ notes }) => {
+const NotesList: React.FC<Props> = ({ focusedNoteId, notes }) => {
   const editorMode = useReactiveVar(editorModeVar);
   const isEditorEditMode = editorMode === EditorMode.Edit;
   const ItemWrapper = isEditorEditMode ? EmptyWrapper : LinkWrapper;
@@ -54,7 +56,10 @@ const NotesList: React.FC<Props> = ({ notes }) => {
     <div style={{ flex: 1, overflow: 'scroll' }}>
       {notes.map(note => (
         <ItemWrapper key={note.id} href={`/?noteId=${note.id}`} passHref>
-          <Item style={{ cursor: isEditorEditMode ? 'default' : 'pointer' }}>
+          <Item
+            isActive={focusedNoteId === note.id}
+            isEditMode={isEditorEditMode}
+          >
             <p>{note.name}</p>
           </Item>
         </ItemWrapper>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -8,6 +8,7 @@ import { editorModeVar, setEditorMode } from '@/gql/editorModeCache';
 import { NoteFragments } from '@/gql/fragments';
 import { CREATE_NOTE } from '@/gql/mutation';
 import { CreateNote, CreateNoteVariables } from '@/typings/gql';
+import { media } from '@/utils/theme';
 import { useMutation, useReactiveVar } from '@apollo/client';
 
 import ToggleTheme from './ToggleTheme';
@@ -33,6 +34,19 @@ const Button = styled.button`
   font-size: 1.2rem;
   background: ${p => p.theme.colors.main};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+
+  ${media('pad')} {
+    width: 50%;
+    font-size: 1rem;
+    padding: 0.5rem;
+  }
+`;
+
+const StyledPlus = styled(BiPlusMedical)`
+  margin-right: 10px;
+  ${media('pad')} {
+    margin-right: 5px;
+  }
 `;
 
 const TopBar: React.FC = () => {
@@ -70,7 +84,7 @@ const TopBar: React.FC = () => {
         onClick={() => createNote()}
         disabled={editorMode === EditorMode.Edit}
       >
-        <BiPlusMedical size="20px" style={{ marginRight: '10px' }} />
+        <StyledPlus size="20px" />
         New note
       </Button>
       <ToggleTheme />

--- a/gql/fragments.ts
+++ b/gql/fragments.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client';
+
+export const NoteFragments = {
+  newNote: gql`
+    fragment NewNote on Note {
+      id
+      name
+      content
+      createdAt
+    }
+  `,
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,16 +16,18 @@ const App = () => {
     const parsed = queryString.parse(location.search);
     noteId = parsed.noteId as string;
   }
-
   const { data: notesData } = useQuery<GetNotes>(GET_NOTES);
   const { data: noteData } = useQuery<GetNote, GetNoteVariables>(GET_NOTE, {
     variables: { id: noteId },
     skip: !noteId,
   });
 
-  // if noteData changed, alway back to View mode first.
+  // if noteId exist but noteData is not found,
+  // the note might be deleted, back to view mode first.
   useEffect(() => {
-    setEditorMode(EditorMode.View);
+    if (noteData?.note === null) {
+      setEditorMode(EditorMode.View);
+    }
   }, [noteData?.note]);
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ const App = () => {
 
   return (
     <AppLayout>
-      <NotesList notes={notesData?.notes || []} />
+      <NotesList focusedNoteId={noteId} notes={notesData?.notes || []} />
       {noteData?.note && noteId && (
         /* key for re-mount when noteId changed */
         <Content key={noteId} note={noteData.note} />


### PR DESCRIPTION
### description

This pr implements:
1. After create note, just directly update cache instead of refetching notes, because it can reduce request times from network.
2. auto focus after createNote
3. add isActive in NoteList

### demo

https://www.notion.so/mengtse/Auto-focus-when-create-note-aa2557648160469086daf73c1dac76e1